### PR TITLE
fix link to general README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ This module expects three fields on the passed `options` object: `.dstBucket`, `
 
 It will upload an object at the specified filepath to S3 at the specifed bucket and key. 
 
-NOTE: See the [general Lambduh README]() for info on the `options` object flow. (In short, an `options` object is expected to flow through the full promise chain, and modules are expected to act on it or pass it on, or both).
+NOTE: See the [general Lambduh README](https://github.com/lambduh/lambduh#usage---options-object-flow) for info on the `options` object flow. (In short, an `options` object is expected to flow through the full promise chain, and modules are expected to act on it or pass it on, or both).
 
 # Full disclosure
 
 This module's tests don't yet cover the `aws-sdk` implementation - only the validation and other basic things.
-I'm hoping to get back to this soon....
 
+I'm hoping to get back to this soon....


### PR DESCRIPTION
Just fixing a link to the General README.

Sorry if this is obnoxious!!!

There's only one more in the other module.  :)
