### PR TITLE
Allow the user to specify the region of the S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ exports.handler = function(event, context) {
 
 This module expects three fields on the passed `options` object: `.dstBucket`, `.dstKey`, and `.uploadFilepath`
 
-It will upload an object at the specified filepath to S3 at the specifed bucket and key.
+By default this will use the default region the lambda operates in.  If you need to operate on an S3 bucket in another region you can set the region field on the `options` object: `.region`.
+
+It will upload an object at the specified filepath to S3 at the specifed bucket, key and region (if specified).
 
 # Full disclosure
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,11 @@ module.exports = function(result, options) {
     }
 
     var file = fs.createReadStream(options.uploadFilepath);
-    var S3 = new AWS.S3({params: params});
+    if (options.region) {
+      var S3 = new AWS.S3({params: params, region: options.region});
+    } else {
+      var S3 = new AWS.S3({params: params});
+    }
     S3.upload({Body: file})
       .on('httpUploadProgress', function(evt) {
         console.log('Upload Progress: ' + (100 * evt.loaded / evt.total));


### PR DESCRIPTION
Hi,

The region I have my S3 buckets in unfortunately does not support AWS lambda.  I have made a minor change to your module to support specifying the region for the s3 bucket.

This should only be a minor version bump as I made it optional to specify the region.

Thanks,

Peter.
