### PR TITLE
Allow an ACL option for objects to be uploaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,15 @@ module.exports = function(result, options) {
       result[key] = options[key];
     }
 
+    if(!options.ACL){
+      options.ACL = 'private';
+    }
+
     var params = {
       Bucket: options.dstBucket,
       Key: options.dstKey,
-      ContentType: mime.lookup(options.uploadFilepath)
+      ContentType: mime.lookup(options.uploadFilepath),
+      ACL: options.ACL
     }
 
     var file = fs.createReadStream(options.uploadFilepath);


### PR DESCRIPTION
By default, I believe, when uploading a file using
`lambduh-put-s3-object` it will put the file up with the 'private' as
the ACL, with no ability to define an alternative policyw. This should
allow library users to define the ACL that files should be uploaded with
instead.

NOTE: Tests needed
