### PR TITLE
Added support for s3 metadata + test + documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,28 @@ This module expects three fields on the passed `options` object: `.dstBucket`, `
 By default this will use the default region the lambda operates in.  If you need to operate on an S3 bucket in another region you can set the region field on the `options` object: `.region`.
 
 It will upload an object at the specified filepath to S3 at the specifed bucket, key and region (if specified).
-
+#Metadata
+You can pass addional metadata on your object by specifying a Metadata 
+object in your params for example
+```javascript
+options= {
+      dstBucket: testBucketName,
+      dstKey: "my-red-lil-key.png",
+      uploadFilepath: "/tmp/my-red-lil-key.png",
+      Metadata:{
+                     language :'EN',
+                     dialect:'us',
+                     encoding: 'utf8',
+                     client_class:'premium'
+                   }
+```
+Like most things in AWS, Metadata is fraught with subtle nightmares,
+    read [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-metadata)
+     for all the things you can get wrong.
+For the gist, AWS will add **x-amz-meta** as a prefix to all of your 
+metadata, and make it all lowercase. It won't accept non ascii metadata
+and it may or may not tell you about it. 
+See the tests for an example of how to use it.
 # Full disclosure
 
 This module's tests don't yet cover the `aws-sdk` implementation - only the validation and other basic things.

--- a/index.js
+++ b/index.js
@@ -24,8 +24,13 @@ module.exports = function(result, options) {
     var params = {
       Bucket: options.dstBucket,
       Key: options.dstKey,
-      ContentType: mime.lookup(options.uploadFilepath)
+      ContentType: mime.lookup(options.uploadFilepath),
     };
+    if (options.Metadata) {
+      params["Metadata"] = options.Metadata
+    }
+    console.log(params);
+
 
     if (options.ACL) {
       params.ACL = options.ACL;

--- a/test/put-s3-object.spec.js
+++ b/test/put-s3-object.spec.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect;
-
+var testBucketName ='lambduh-upload-test-bucket';
+//var testBucketName ='my-lil-red-bucket';
 var put = require('../');
 
 describe('putS3Object', function() {
@@ -38,7 +39,7 @@ describe('putS3Object', function() {
 
     it('should require Key param', function(done) {
       var options = {
-        dstBucket: "my-lil-red-bucket"
+        dstBucket: testBucketName
       }
       put(null, options).then(function() {
         done(new Error('Expected function to throw error'));
@@ -53,7 +54,7 @@ describe('putS3Object', function() {
 
     it('should require uploadFilepath param', function(done) {
       var options = {
-        dstBucket: "my-lil-red-bucket",
+        dstBucket: testBucketName,
         dstKey: "my-red-lil-key.png"
       }
       put(null, options).then(function() {
@@ -71,7 +72,7 @@ describe('putS3Object', function() {
   //TODO: implement properly - mock AWS.S3 .upload() and .send()
   xit('should resolve the options object when required params are included', function(done) {
     var options = {
-      dstBucket: "my-lil-red-bucket",
+      dstBucket: testBucketName,
       dstKey: "my-red-lil-key.png",
       uploadFilepath: "/tmp/my-red-lil-key.png",
       key: 'val'
@@ -87,4 +88,51 @@ describe('putS3Object', function() {
     })
   });
 
-});
+  it('should resolve Metadat objects when Metadat is included', function(done) {
+    var metadata = {
+      language :'EN',
+      dialect:'us',
+      encoding: 'utf8',
+      client_class:'premium'
+    }
+    var options = {
+      dstBucket: testBucketName,
+      dstKey: "my-red-lil-key.png",
+      uploadFilepath: "/tmp/my-red-lil-key.png",
+      Metadata:metadata,
+
+    }
+    put(null, options).then(function(opts) {
+
+
+      if (opts.Metadata===metadata) {
+        done();
+      } else {
+        done(new Error('Expected resolved options metadata to match inputted metadata'));
+      }
+    }, function(opts) {
+      console.log(opts);
+      done(new Error('Expected function to pass but it did not'));
+    })
+
+  });
+  //Disabled by default since when you upload it it runs over the previous one and is hard to check
+  xit('should not send MetaData if no MetaData was provided', function(done) {
+    var options = {
+      dstBucket: testBucketName,
+      dstKey: "my-red-lil-key.png",
+      uploadFilepath: "/tmp/my-red-lil-key.png",
+
+    }
+    put(null, options).then(function(opts) {
+      if (true ) {
+        done();
+      } else {
+        done(new Error('Expected metadata to be undefined in resolved opts if no metadata was passed'));
+      }
+    }, function() {
+      done(new Error('Expected function to pass'));
+    })
+
+  });
+  });


### PR DESCRIPTION
I wanted to use this great lib but also be able to add metadata to my objects. Added the functionality with tests and some docs. 
Let me know if I can add anything to get this in and thanks for putting this time saver up!
